### PR TITLE
Add 'combine_by_group' option

### DIFF
--- a/src/Lightgear/Asset/Asset.php
+++ b/src/Lightgear/Asset/Asset.php
@@ -321,7 +321,7 @@ class Asset {
 
         // publish combined assets
         if ($combine) {
-            $output .= $this->publishCombined($combinedContents, $type);
+            $output .= $this->publishCombined($combinedContents, $type, $group);
         }
 
         // cache asset resurce
@@ -343,9 +343,15 @@ class Asset {
      * @param  string $type     The assets type
      * @return string           The link to the asset resource
      */
-    protected function publishCombined($contents, $type)
+    protected function publishCombined($contents, $type, $group = 'general')
     {
-        $filename = $this->config->get('asset::combined_' . $type);
+        if ($this->config->get('asset::combine_by_group') && $group !== 'general') {
+            $prefix = $group . '/';
+        } else {
+            $prefix = '';
+        }
+
+        $filename = $prefix . $this->config->get('asset::combined_' . $type);
 
         $assetData = $this->buildTargetPaths(
             $filename,

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -38,6 +38,12 @@ return array(
     'combine' => false,
 
     /**
+     * Instead of combining all files into one, create one
+     * combined file for each group.
+     */
+    'combine_by_group' => false,
+
+    /**
      * The filename of the combined styles.
      */
     'combined_styles' => 'application.css',


### PR DESCRIPTION
Thanks for this excellent package. One problem we ran into was that we had a few distinct areas of our application that needed different asset groups. But, we also wanted to take advantage of the `combine` option. As it is now, this creates one single combined file for the entire application, including all groups. This commit introduces an opt-in option that will rendered the combined assets by group instead.

Old behavior:

``` php
Asset::register(
    array(
        'css/core/reset.css',
        'css/core/style.less',
    ), array('group' => 'core')
);

Asset::register(
    array(
        'css/core/reset.css',
        'css/site/style.less',
    ), array('group' => 'site')
);

Asset::styles('core');
 // <link href="https://example.com/assets/application.css?aFvF4eK2kG" media="all" type="text/css" rel="stylesheet">

Asset::styles('site');
 // <link href="https://example.com/assets/application.css?aFvF4eK2kG" media="all" type="text/css" rel="stylesheet">
```

The rendered combined style would only include the last group (`site` in this case).

New behavior:

``` php
Asset::register(
    array(
        'css/core/reset.css',
        'css/core/style.less',
    ), array('group' => 'core')
);

Asset::register(
    array(
        'css/core/reset.css',
        'css/site/style.less',
    ), array('group' => 'site')
);

Asset::styles('core');
 // <link href="https://example.com/assets/core/application.css?aFvF4eK2kG" media="all" type="text/css" rel="stylesheet">

Asset::styles('site');
 // <link href="https://example.com/assets/site/application.css?aFvF4eK2kG" media="all" type="text/css" rel="stylesheet">
```
