### PR TITLE
Composer Fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,18 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.x",
-        "leafo/lessphp": "0.4.0",
-        "mrclay/minify": "dev-master"
+        "illuminate/support": "4.*",
+        "leafo/lessphp": "0.4.*",
+        "mrclay/minify": "2.1.*"
     },
     "autoload": {
         "psr-0": {
             "Lightgear\\Asset": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
- Alias the branch as 2.0 so we can install it through composer by asking for "2.0.*"
- Tweak the other requirements and fix mrclay/minify (it's always better to use versions instead of branches)
